### PR TITLE
Revert "ci: Disable e2e-tests for release"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,7 @@ lint:
 
 .PHONY: e2e-tests
 e2e-tests: annotated-policy.wasm
-	true
-	# bats e2e.bats
-	# Temporarily disable e2e-tests for the release; to run they need a kwctl with
-	# the changes to the sdk and policy-evaluator, which are unreleased as these
-	# run this specific policy in the integration tests.
-	# The e2e-tests should be reinstated after the policy release.
+	bats e2e.bats
 
 .PHONY: test
 test: fmt lint


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
This reverts commit b1f6ec0fe9fe5eb812f71c5ec1446a41e3d0609b,
re-enabling the e2e-tests after the release has been done.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->


<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
