### PR TITLE
Reapply "ci: Disable e2e-tests for release"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,12 @@ lint:
 
 .PHONY: e2e-tests
 e2e-tests: annotated-policy.wasm
-	bats e2e.bats
+	true
+	# bats e2e.bats
+	# Temporarily disable e2e-tests for the release; to run they need a kwctl with
+	# the changes to the sdk and policy-evaluator, which are unreleased as these
+	# run this specific policy in the integration tests.
+	# The e2e-tests should be reinstated after the policy release.
 
 .PHONY: test
 test: fmt lint


### PR DESCRIPTION
## Description

This reverts commit 766dc03d2144f993a3a8ba65dd8a155c1d1dd60b. Required to release this policy to be used in policy-evaluator CI. 
